### PR TITLE
feat: allow passing on cookies and change backend url by header

### DIFF
--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -80,6 +80,8 @@ function nav(): DefaultTheme.NavItem[] {
           items: [
             { text: 'Hydration', link: '/guide/hydration' },
             { text: 'Caching', link: '/guide/caching' },
+            { text: 'Cookies', link: '/guide/cookies' },
+            { text: 'Dynamic Backend URL', link: '/guide/dynamic-backend-url' },
           ],
         },
       ],
@@ -137,6 +139,8 @@ function sidebarGuide(): DefaultTheme.SidebarItem[] {
       items: [
         { text: 'Hydration', link: '/guide/hydration' },
         { text: 'Caching', link: '/guide/caching' },
+        { text: 'Cookies', link: '/guide/cookies' },
+        { text: 'Dynamic Backend URL', link: '/guide/dynamic-backend-url' },
       ],
     },
     {

--- a/docs/config/index.md
+++ b/docs/config/index.md
@@ -23,6 +23,7 @@ Main module configuration for your API endpoints. Each key represents an endpoin
 - `token`: The API token to use for the endpoint (optional)
 - `query`: Query parameters to send with the each request (optional)
 - `headers`: Headers to send with each request (optional)
+- `cookies`: Whether to send cookies with each request (optional)
 
 ::: info
 The composables are generated based on your API endpoint ID. For example, if you were to call an endpoint `jsonPlaceholder`, the composables will be called `useJsonPlaceholderData` and `$jsonPlaceholder`.
@@ -40,6 +41,7 @@ type ApiPartyEndpoints = Record<
     token?: string
     query?: QueryObject
     headers?: Record<string, string>
+    cookies?: boolean
   }
 > | undefined
 ```

--- a/docs/guide/cookies.md
+++ b/docs/guide/cookies.md
@@ -1,0 +1,24 @@
+# Cookies
+
+Sometimes your authorization token is stored in a cookie (e.g. coming from SSO). In this case, you can set `cookies` to `true` in your endpoint configuration to send cookies with each request.
+
+## Examples
+
+::: info
+The examples below assume that you have set up an API endpoint called `jsonPlaceholder`. The API endpoint is authorized by a cookie which is provided by an external SSO service. To pass on the cookie provided by the external SSO, you can enable `cookies` in your endpoint configuration.:
+
+```ts
+// `nuxt.config.ts`
+export default defineNuxtConfig({
+  modules: ['nuxt-api-party'],
+
+  apiParty: {
+    endpoints: {
+      jsonPlaceholder: {
+        url: 'https://jsonplaceholder.typicode.com',
+        cookies: true
+      }
+    }
+  }
+})
+```

--- a/docs/guide/cookies.md
+++ b/docs/guide/cookies.md
@@ -6,6 +6,7 @@ Sometimes your authorization token is stored in a cookie (e.g. coming from SSO).
 
 ::: info
 The examples below assume that you have set up an API endpoint called `jsonPlaceholder`. The API endpoint is authorized by a cookie which is provided by an external SSO service. To pass on the cookie provided by the external SSO, you can enable `cookies` in your endpoint configuration.
+:::
 
 ```ts
 // `nuxt.config.ts`

--- a/docs/guide/cookies.md
+++ b/docs/guide/cookies.md
@@ -5,7 +5,7 @@ Sometimes your authorization token is stored in a cookie (e.g. coming from SSO).
 ## Examples
 
 ::: info
-The examples below assume that you have set up an API endpoint called `jsonPlaceholder`. The API endpoint is authorized by a cookie which is provided by an external SSO service. To pass on the cookie provided by the external SSO, you can enable `cookies` in your endpoint configuration.:
+The examples below assume that you have set up an API endpoint called `jsonPlaceholder`. The API endpoint is authorized by a cookie which is provided by an external SSO service. To pass on the cookie provided by the external SSO, you can enable `cookies` in your endpoint configuration.
 
 ```ts
 // `nuxt.config.ts`

--- a/docs/guide/dynamic-backend-url.md
+++ b/docs/guide/dynamic-backend-url.md
@@ -6,7 +6,7 @@ If you need to change the backend URL at runtime, you can do so by using a custo
 
 ::: info
 
-The examples below assume that you have set up an API endpoint called `jsonPlaceholder`. In this case you can use the `JSON_PLACEHOLDER_BACKEND_URL` header to change the backend URL at runtime.:
+The examples below assume that you have set up an API endpoint called `jsonPlaceholder`. In this case you can use the `JSON_PLACEHOLDER_BACKEND_URL` header to change the backend URL at runtime.
 
 ```ts
 const { data } = await useJsonPlaceholderData(

--- a/docs/guide/dynamic-backend-url.md
+++ b/docs/guide/dynamic-backend-url.md
@@ -5,15 +5,15 @@ If you need to change the backend URL at runtime, you can do so by using a custo
 ## Example
 
 ::: info
-
-The examples below assume that you have set up an API endpoint called `jsonPlaceholder`. In this case you can use the `JSON_PLACEHOLDER_BACKEND_URL` header to change the backend URL at runtime.
+The examples below assume that you have set up an API endpoint called `jsonPlaceholder`. In this case you can use the `JSON_PLACEHOLDER_ENDPOINT_URL` header to change the backend URL at runtime.
+:::
 
 ```ts
 const { data } = await useJsonPlaceholderData(
   'comments',
   {
     headers: {
-      JSON_PLACEHOLDER_BACKEND_URL: 'https://jsonplaceholder-v2.typicode.com'
+      JSON_PLACEHOLDER_ENDPOINT_URL: 'https://jsonplaceholder-v2.typicode.com'
     }
   }
 )

--- a/docs/guide/dynamic-backend-url.md
+++ b/docs/guide/dynamic-backend-url.md
@@ -1,0 +1,20 @@
+# Dynamic Backend URL
+
+If you need to change the backend URL at runtime, you can do so by using a custom header based on the endpoint name. This is useful for example when you have a multi-tenant application where each tenant has its own backend URL.
+
+## Example
+
+::: info
+
+The examples below assume that you have set up an API endpoint called `jsonPlaceholder`. In this case you can use the `JSON_PLACEHOLDER_BACKEND_URL` header to change the backend URL at runtime.:
+
+```ts
+const { data } = await useJsonPlaceholderData(
+  'comments',
+  {
+    headers: {
+      JSON_PLACEHOLDER_BACKEND_URL: 'https://jsonplaceholder-v2.typicode.com'
+    }
+  }
+)
+```

--- a/src/module.ts
+++ b/src/module.ts
@@ -13,6 +13,7 @@ export interface ModuleOptions {
    * - `token`: The API token to use for the endpoint (optional)
    * - `query`: Query parameters to send with the each request (optional)
    * - `headers`: Headers to send with each request (optional)
+   * - `cookies`: Whether to send cookies with each request (optional)
    *
    * @example
    * export default defineNuxtConfig({
@@ -37,6 +38,7 @@ export interface ModuleOptions {
       token?: string
       query?: QueryObject
       headers?: Record<string, string>
+      cookies?: boolean
     }
   >
 

--- a/src/runtime/composables/$api.ts
+++ b/src/runtime/composables/$api.ts
@@ -55,6 +55,11 @@ export function _$api<T = any>(
   const endpoints = (apiParty as ModuleOptions).endpoints || {}
   const endpoint = endpoints[endpointId]
 
+  const _headers = {
+    ...headers,
+    ...useRequestHeaders(['cookie']),
+  }
+
   const clientFetcher = () => globalThis.$fetch<T>(path, {
     ...fetchOptions,
     baseURL: endpoint.url,
@@ -66,7 +71,7 @@ export function _$api<T = any>(
     headers: {
       ...(endpoint.token && { Authorization: `Bearer ${endpoint.token}` }),
       ...endpoint.headers,
-      ...headersToObject(headers),
+      ...headersToObject(_headers),
     },
     body,
   }) as Promise<T>
@@ -78,7 +83,7 @@ export function _$api<T = any>(
       body: {
         path,
         query,
-        headers: headersToObject(headers),
+        headers: headersToObject(_headers),
         method,
         body: await serializeMaybeEncodedBody(body),
       } satisfies EndpointFetchOptions,

--- a/src/runtime/composables/$api.ts
+++ b/src/runtime/composables/$api.ts
@@ -4,7 +4,7 @@ import { headersToObject, serializeMaybeEncodedBody } from '../utils'
 import { isFormData } from '../formData'
 import type { ModuleOptions } from '../../module'
 import type { EndpointFetchOptions } from '../utils'
-import { useNuxtApp, useRuntimeConfig } from '#imports'
+import { useNuxtApp, useRequestHeaders, useRuntimeConfig } from '#imports'
 
 export type ApiFetchOptions = Omit<NitroFetchOptions<string>, 'body' | 'cache'> & {
   body?: string | Record<string, any> | FormData | null
@@ -55,11 +55,6 @@ export function _$api<T = any>(
   const endpoints = (apiParty as ModuleOptions).endpoints || {}
   const endpoint = endpoints[endpointId]
 
-  const _headers = {
-    ...headers,
-    ...useRequestHeaders(['cookie']),
-  }
-
   const clientFetcher = () => globalThis.$fetch<T>(path, {
     ...fetchOptions,
     baseURL: endpoint.url,
@@ -71,7 +66,7 @@ export function _$api<T = any>(
     headers: {
       ...(endpoint.token && { Authorization: `Bearer ${endpoint.token}` }),
       ...endpoint.headers,
-      ...headersToObject(_headers),
+      ...headersToObject(headers),
     },
     body,
   }) as Promise<T>
@@ -83,7 +78,10 @@ export function _$api<T = any>(
       body: {
         path,
         query,
-        headers: headersToObject(_headers),
+        headers: {
+          ...headersToObject(headers),
+          ...useRequestHeaders(['cookie']),
+        },
         method,
         body: await serializeMaybeEncodedBody(body),
       } satisfies EndpointFetchOptions,

--- a/src/runtime/composables/useApiData.ts
+++ b/src/runtime/composables/useApiData.ts
@@ -78,10 +78,15 @@ export function _useApiData<T = any>(
 
   const _fetchOptions = reactive(fetchOptions)
 
+  const _headers = {
+    ...headers,
+    ...useRequestHeaders(['cookie']),
+  }
+
   const _endpointFetchOptions: EndpointFetchOptions = reactive({
     path: _path,
     query,
-    headers: computed(() => headersToObject(toValue(headers))),
+    headers: computed(() => headersToObject(toValue(_headers))),
     method,
     body,
   })

--- a/src/runtime/composables/useApiData.ts
+++ b/src/runtime/composables/useApiData.ts
@@ -78,15 +78,13 @@ export function _useApiData<T = any>(
 
   const _fetchOptions = reactive(fetchOptions)
 
-  const _headers = {
-    ...headers,
-    ...useRequestHeaders(['cookie']),
-  }
-
   const _endpointFetchOptions: EndpointFetchOptions = reactive({
     path: _path,
     query,
-    headers: computed(() => headersToObject(toValue(_headers))),
+    headers: computed(() => ({
+      ...headersToObject(toValue(headers)),
+      ...useRequestHeaders(['cookie']),
+    })),
     method,
     body,
   })

--- a/src/runtime/server.ts
+++ b/src/runtime/server.ts
@@ -1,4 +1,5 @@
 import { createError, defineEventHandler, getRouterParams, readBody } from 'h3'
+import { snakeCase } from 'scule'
 import destr from 'destr'
 import type { FetchError } from 'ofetch'
 import type { ModuleOptions } from '../module'
@@ -37,12 +38,17 @@ export default defineEventHandler(async (event): Promise<any> => {
   // Pass on cookies to the backend if the endpoint is configured to do so
   const cookies = endpoint.cookies ? parseCookies(event) : undefined
 
+  // Allow to overwrite the backend url with a custom header (e.g. jsonPlaceholder endpoint
+  // becomes JSON_PLACEHOLDER_BACKEND_URL)
+  const customBackendURLHeader = `${snakeCase(endpointId).toUpperCase()}_BACKEND_URL`
+  const baseURL = new Headers(headers).get(customBackendURLHeader) || endpoint.url
+
   try {
     return await $fetch(
       path!,
       {
         ...fetchOptions,
-        baseURL: endpoint.url,
+        baseURL,
         query: {
           ...endpoint.query,
           ...query,

--- a/src/runtime/server.ts
+++ b/src/runtime/server.ts
@@ -56,9 +56,9 @@ export default defineEventHandler(async (event): Promise<any> => {
         headers: {
           ...(endpoint.token && { Authorization: `Bearer ${endpoint.token}` }),
           ...endpoint.headers,
+          cookie: getRequestHeader(event, 'cookie') as string,
           ...headers,
         },
-        cookies,
         ...(body && { body: await deserializeMaybeEncodedBody(body) }),
       },
     )

--- a/src/runtime/server.ts
+++ b/src/runtime/server.ts
@@ -34,6 +34,9 @@ export default defineEventHandler(async (event): Promise<any> => {
     ...fetchOptions
   } = _body
 
+  // Pass on cookies to the backend if the endpoint is configured to do so
+  const cookies = endpoint.cookies ? parseCookies(event) : undefined
+
   try {
     return await $fetch(
       path!,
@@ -49,6 +52,7 @@ export default defineEventHandler(async (event): Promise<any> => {
           ...endpoint.headers,
           ...headers,
         },
+        cookies,
         ...(body && { body: await deserializeMaybeEncodedBody(body) }),
       },
     )

--- a/src/runtime/server.ts
+++ b/src/runtime/server.ts
@@ -1,5 +1,4 @@
 import { createError, defineEventHandler, getRouterParams, readBody } from 'h3'
-import { snakeCase } from 'scule'
 import destr from 'destr'
 import type { FetchError } from 'ofetch'
 import type { ModuleOptions } from '../module'
@@ -35,13 +34,9 @@ export default defineEventHandler(async (event): Promise<any> => {
     ...fetchOptions
   } = _body
 
-  // Pass on cookies to the backend if the endpoint is configured to do so
-  const cookies = endpoint.cookies ? parseCookies(event) : undefined
-
-  // Allow to overwrite the backend url with a custom header (e.g. jsonPlaceholder endpoint
-  // becomes JSON_PLACEHOLDER_BACKEND_URL)
-  const customBackendURLHeader = `${snakeCase(endpointId).toUpperCase()}_BACKEND_URL`
-  const baseURL = new Headers(headers).get(customBackendURLHeader) || endpoint.url
+  // Allows to overwrite the backend url with a custom header
+  // (e.g. `jsonPlaceholder` endpoint becomes `JSON_PLACEHOLDER_ENDPOINT_URL`)
+  const baseURL = new Headers(headers).get(`${endpointId}_endpoint_url`) || endpoint.url
 
   try {
     return await $fetch(
@@ -55,7 +50,7 @@ export default defineEventHandler(async (event): Promise<any> => {
         },
         headers: {
           ...(endpoint.token && { Authorization: `Bearer ${endpoint.token}` }),
-          cookie: getRequestHeader(event, 'cookie') as string,
+          ...(endpoint.cookies && { cookie: getRequestHeader(event, 'cookie') }),
           ...endpoint.headers,
           ...headers,
         },

--- a/src/runtime/server.ts
+++ b/src/runtime/server.ts
@@ -55,8 +55,8 @@ export default defineEventHandler(async (event): Promise<any> => {
         },
         headers: {
           ...(endpoint.token && { Authorization: `Bearer ${endpoint.token}` }),
-          ...endpoint.headers,
           cookie: getRequestHeader(event, 'cookie') as string,
+          ...endpoint.headers,
           ...headers,
         },
         ...(body && { body: await deserializeMaybeEncodedBody(body) }),


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)
-->

### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [x] 📖 Documentation (updates to the documentation, readme or JSDoc annotations)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [x] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

# Cookies

Sometimes your authorization token is stored in a cookie (e.g. coming from SSO). In this case, you can set `cookies` to `true` in your endpoint configuration to send cookies with each request.

## Examples

::: info
The examples below assume that you have set up an API endpoint called `jsonPlaceholder`. The API endpoint is authorized by a cookie which is provided by an external SSO service. To pass on the cookie provided by the external SSO, you can enable `cookies` in your endpoint configuration.:

```ts
// `nuxt.config.ts`
export default defineNuxtConfig({
  modules: ['nuxt-api-party'],

  apiParty: {
    endpoints: {
      jsonPlaceholder: {
        url: 'https://jsonplaceholder.typicode.com',
        cookies: true
      }
    }
  }
})
```

# Dynamic Backend URL

If you need to change the backend URL at runtime, you can do so by using a custom header based on the endpoint name. This is useful for example when you have a multi-tenant application where each tenant has its own backend URL.

## Example

::: info

The examples below assume that you have set up an API endpoint called `jsonPlaceholder`. In this case you can use the `JSON_PLACEHOLDER_BACKEND_URL` header to change the backend URL at runtime.:

```ts
const { data } = await useJsonPlaceholderData(
  'comments',
  {
    headers: {
      JSON_PLACEHOLDER_BACKEND_URL: 'https://jsonplaceholder-v2.typicode.com'
    }
  }
)
```

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [x] I have updated the documentation accordingly.
