### PR TITLE
fix: some OpenAPI types

### DIFF
--- a/playground/pages/petStore.vue
+++ b/playground/pages/petStore.vue
@@ -7,6 +7,27 @@ type Pet = components['schemas']['Pet']
 const availableStatus = ['pending', 'sold'] as const
 const status = ref<'pending' | 'sold'>()
 
+const { data: user, execute } = usePetStoreData('user/{username}', {
+  pathParams: { username: 'user1' },
+})
+
+async function updateUser() {
+  try {
+    // will error because of authentication
+    await $petStore('user/{username}', {
+      method: 'put',
+      pathParams: { username: 'user1' },
+      body: {
+        firstName: 'first name 2',
+      },
+    })
+    await execute()
+  }
+  catch (e) {
+    console.error(e)
+  }
+}
+
 const { data, error } = usePetStoreData('pet/findByStatus', {
   query: computed(() => ({
     status: status.value ?? 'pending',
@@ -67,6 +88,13 @@ async function abandonGarfield() {
 
 <template>
   <div>
+    <h2>User</h2>
+    <p v-if="user" class="name">
+      {{ user.firstName }} {{ user.lastName }}
+      <button @click="updateUser">
+        Update
+      </button>
+    </p>
     <h2>usePetStoreData</h2>
     <p>Status: {{ status }}</p>
     <p>
@@ -91,3 +119,9 @@ async function abandonGarfield() {
     </p>
   </div>
 </template>
+
+<style scoped>
+.name {
+  text-transform: capitalize;
+}
+</style>

--- a/src/runtime/composables/$api.ts
+++ b/src/runtime/composables/$api.ts
@@ -4,7 +4,7 @@ import { headersToObject, resolvePath, serializeMaybeEncodedBody } from '../util
 import { isFormData } from '../formData'
 import type { ModuleOptions } from '../../module'
 import type { EndpointFetchOptions } from '../utils'
-import type { AllPaths, GETPlainPaths, HttpMethod, IgnoreCase, OpenApiRequestOptions, OpenApiResponse, PathItemObject } from '../types'
+import type { AllPaths, GETPaths, GETPlainPaths, HttpMethod, IgnoreCase, OpenApiRequestOptions, OpenApiResponse, PathItemObject } from '../types'
 import { useNuxtApp, useRequestHeaders, useRuntimeConfig } from '#imports'
 
 export interface BaseApiFetchOptions {
@@ -33,11 +33,16 @@ export type $Api = <T = any>(
 
 export interface $OpenApi<Paths extends Record<string, PathItemObject>> {
   <P extends GETPlainPaths<Paths>>(
-    path: P
+    path: P,
+    opts?: BaseApiFetchOptions & Omit<OpenApiRequestOptions<Paths[`/${P}`]>, 'method'>
+  ): Promise<OpenApiResponse<Paths[`/${P}`]['get']>>
+  <P extends GETPaths<Paths>>(
+    path: P,
+    opts: BaseApiFetchOptions & Omit<OpenApiRequestOptions<Paths[`/${P}`]>, 'method'>
   ): Promise<OpenApiResponse<Paths[`/${P}`]['get']>>
  <P extends AllPaths<Paths>, M extends IgnoreCase<keyof Paths[`/${P}`] & HttpMethod>>(
     path: P,
-    opts?: BaseApiFetchOptions & OpenApiRequestOptions<Paths[`/${P}`], M>
+    opts?: BaseApiFetchOptions & OpenApiRequestOptions<Paths[`/${P}`], M> & { method: M }
   ): Promise<OpenApiResponse<Paths[`/${P}`][Lowercase<M>]>>
 }
 


### PR DESCRIPTION
1. Fix inference with endpoint method overloads
2. Require opts with method when an endpoint doesn't have GET
3. `useApiData` should also have undefined as a possible data generic

<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)
-->

### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme or JSDoc annotations)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
