### PR TITLE
fix: omit `cache` from `NitroFetchOptions`

### DIFF
--- a/playground/pages/petStore.vue
+++ b/playground/pages/petStore.vue
@@ -9,6 +9,7 @@ const status = ref<'pending' | 'sold'>()
 
 const { data: user, execute } = usePetStoreData('user/{username}', {
   pathParams: { username: 'user1' },
+  cache: true,
 })
 
 async function updateUser() {
@@ -20,6 +21,7 @@ async function updateUser() {
       body: {
         firstName: 'first name 2',
       },
+      cache: false,
     })
     await execute()
   }

--- a/src/runtime/types.ts
+++ b/src/runtime/types.ts
@@ -55,7 +55,7 @@ export type OpenApiRequestOptions<
   M extends IgnoreCase<keyof P & HttpMethod> = IgnoreCase<keyof P & 'get'>,
 > = Omit<
   NitroFetchOptions<any, Lowercase<M>>,
-  'params' | 'query' | 'headers' | 'method' | 'body'
+  'params' | 'query' | 'headers' | 'method' | 'body' | 'cache'
 > & RequestBody<P[Lowercase<M>]> & PathParameters<P[Lowercase<M>]> & QueryParameters<P[Lowercase<M>]> & Method<M>
 
 type MediaTypes<T, Status extends keyof any> = {


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)
-->

### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme or JSDoc annotations)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->

Was preventing manual caching with OpenAPI endpoints.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
