### PR TITLE
fix: error type is `useApiData` is a `FetchError`

### DIFF
--- a/src/runtime/composables/useApiData.ts
+++ b/src/runtime/composables/useApiData.ts
@@ -69,15 +69,15 @@ export interface UseOpenApiData<Paths extends Record<string, PathItemObject>> {
   <P extends GETPlainPaths<Paths>>(
     path: MaybeRefOrGetter<P>,
     opts?: Omit<UseOpenApiDataOptions<Paths[`/${P}`]>, 'method'>,
-  ): AsyncData<OpenApiResponse<Paths[`/${P}`]['get']> | undefined, OpenApiError<Paths[`/${P}`]['get']>>
+  ): AsyncData<OpenApiResponse<Paths[`/${P}`]['get']> | undefined, FetchError<OpenApiError<Paths[`/${P}`]['get']>>>
   <P extends GETPaths<Paths>>(
     path: MaybeRefOrGetter<P>,
     opts: Omit<UseOpenApiDataOptions<Paths[`/${P}`]>, 'method'>,
-  ): AsyncData<OpenApiResponse<Paths[`/${P}`]['get']> | undefined, OpenApiError<Paths[`/${P}`]['get']>>
+  ): AsyncData<OpenApiResponse<Paths[`/${P}`]['get']> | undefined, FetchError<OpenApiError<Paths[`/${P}`]['get']>>>
 <P extends AllPaths<Paths>, M extends IgnoreCase<keyof Paths[`/${P}`] & HttpMethod>>(
     path: MaybeRefOrGetter<P>,
     opts: UseOpenApiDataOptions<Paths[`/${P}`], M> & { method: M },
-  ): AsyncData<OpenApiResponse<Paths[`/${P}`][Lowercase<M>]> | undefined, OpenApiError<Paths[`/${P}`][Lowercase<M>]>>
+  ): AsyncData<OpenApiResponse<Paths[`/${P}`][Lowercase<M>]> | undefined, FetchError<OpenApiError<Paths[`/${P}`][Lowercase<M>]>>>
 }
 
 export function _useApiData<T = any>(


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)
-->

### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme or JSDoc annotations)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

The error type in useApiData is incorrect. It's actual type is a `NuxtError` with the `data` type dependent on whether `client: true` is set. If `client: true`, `data` is the response data from the API. Otherwise it is set to what looks like a `IFetchError`.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
