### PR TITLE
fix: allow `pathParams` to be reactive getter

### DIFF
--- a/docs/guide/openapi-types.md
+++ b/docs/guide/openapi-types.md
@@ -145,6 +145,18 @@ const data = await $myApi('foo/{id}', {
 })
 ```
 
+For reactive `pathParams`, pass a ref or getter function instead of a plain object.
+
+```ts
+const id = ref(10)
+
+const data = await $myApi('foo/{id}', {
+  pathParams: () => ({
+    id: id.value
+  })
+})
+```
+
 ::: warning
 Issues will **NOT** be reported at runtime by `nuxt-api-party` if the wrong parameters are used. The **incomplete** path will be sent to the backend **AS IS**.
 :::

--- a/playground/pages/petStore.vue
+++ b/playground/pages/petStore.vue
@@ -25,8 +25,8 @@ async function updateUser() {
     })
     await execute()
   }
-  catch (e) {
-    console.error(e)
+  catch (error) {
+    console.error(error)
   }
 }
 
@@ -50,8 +50,8 @@ async function fetchPetData(petId: number) {
       },
     })
   }
-  catch (e) {
-    console.error(e)
+  catch (error) {
+    console.error(error)
   }
 }
 

--- a/src/runtime/composables/useApiData.ts
+++ b/src/runtime/composables/useApiData.ts
@@ -51,7 +51,7 @@ export type UseApiDataOptions<T> = Pick<
   | 'retryDelay'
   | 'timeout'
 > & {
-  pathParams?: MaybeRef<Record<string, MaybeRefOrGetter<string>>>
+  pathParams?: MaybeRefOrGetter<Record<string, string>>
   body?: MaybeRef<string | Record<string, any> | FormData | null | undefined>
 } & BaseUseApiDataOptions<T>
 

--- a/src/runtime/composables/useApiData.ts
+++ b/src/runtime/composables/useApiData.ts
@@ -51,7 +51,7 @@ export type UseApiDataOptions<T> = Pick<
   | 'retryDelay'
   | 'timeout'
 > & {
-  pathParams?: MaybeRef<Record<string, string>>
+  pathParams?: MaybeRef<Record<string, MaybeRefOrGetter<string>>>
   body?: MaybeRef<string | Record<string, any> | FormData | null | undefined>
 } & BaseUseApiDataOptions<T>
 

--- a/src/runtime/utils.ts
+++ b/src/runtime/utils.ts
@@ -41,12 +41,12 @@ export async function deserializeMaybeEncodedBody(value: ApiFetchOptions['body']
   return value
 }
 
-export function resolvePath(path: string, params?: Record<string, string>) {
+export function resolvePath(path: string, params?: Record<string, MaybeRefOrGetter<unknown>>) {
   // To simplify typings, OpenAPI path parameters can be expanded here
   if (params) {
     return Object.entries(params).reduce(
       (path, [name, value]) =>
-        path.replace(`{${name}}`, encodeURIComponent(value)),
+        path.replace(`{${name}}`, encodeURIComponent(String(toValue(value)))),
       path,
     )
   }

--- a/src/runtime/utils.ts
+++ b/src/runtime/utils.ts
@@ -41,12 +41,11 @@ export async function deserializeMaybeEncodedBody(value: ApiFetchOptions['body']
   return value
 }
 
-export function resolvePath(path: string, params?: Record<string, MaybeRefOrGetter<unknown>>) {
+export function resolvePath(path: string, params?: Record<string, unknown>) {
   // To simplify typings, OpenAPI path parameters can be expanded here
   if (params) {
     return Object.entries(params).reduce(
-      (path, [name, value]) =>
-        path.replace(`{${name}}`, encodeURIComponent(String(toValue(value)))),
+      (path, [name, value]) => path.replace(`{${name}}`, encodeURIComponent(String(value))),
       path,
     )
   }


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)
-->

### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme or JSDoc annotations)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->

`pathParams` didn't support being passed via
```ts
const id = ref("0")
useApiData("endpoint/{id}", { 
  pathParams: { id }
})
```

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
