### PR TITLE
feat: custom `hashFn` composable option

### DIFF
--- a/src/runtime/composables/useApiData.ts
+++ b/src/runtime/composables/useApiData.ts
@@ -40,11 +40,11 @@ export type BaseUseApiDataOptions<T> = Omit<AsyncDataOptions<T>, 'watch'> & {
    * Customize the hash function used to generate the cache key.
    */
   hashFn?: (options: {
-    endpointId: string,
-    path: string,
-    query?: Record<string, any>,
-    method?: string,
-    body?: string | Record<string, any> | null,
+    endpointId: string
+    path: string
+    query?: Record<string, any>
+    method?: string
+    body?: string | Record<string, any> | null
   }) => string
 }
 

--- a/src/runtime/formData.ts
+++ b/src/runtime/formData.ts
@@ -11,7 +11,7 @@ export type SerializedFormData = Record<
 >
 
 export function isFormData(obj: unknown): obj is FormData {
-  return typeof FormData !== 'undefined' && obj instanceof FormData
+  return obj instanceof FormData
 }
 
 export function isSerializedFormData(obj: unknown): obj is SerializedFormData {


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)
-->

### 🔗 Linked issue

Idea from #50

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme or JSDoc annotations)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [x] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

@killjoy1221 To ease the need for your composable overwriting the hashing logic, why not add an option to the composable itself? What do you think?
You could simplify your custom composable.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
