### PR TITLE
feat: customizable cache key

### DIFF
--- a/docs/api/my-api.md
+++ b/docs/api/my-api.md
@@ -17,10 +17,11 @@ interface BaseApiFetchOptions {
    */
   client?: boolean
   /**
-   * Cache the response for the same request
+   * Cache the response for the same request.
+   * If set to `true`, the cache key will be generated from the request options.
    * @default false
    */
-  cache?: boolean
+  cache?: string | boolean
 }
 
 type ApiFetchOptions = Omit<NitroFetchOptions<string>, 'body' | 'cache'> & {
@@ -32,24 +33,18 @@ function $Api<T = any>(
   path: string,
   opts?: ApiFetchOptions & BaseApiFetchOptions
 ): Promise<T>
-function $Api<T = any>(
-  key: string,
-  path: string,
-  opts?: ApiFetchOptions & BaseApiFetchOptions
-): Promise<T>
 ```
 
 ## Caching
 
-By default, a [unique key for each request is generated](/guide/caching) to ensure that data fetching can be properly de-duplicated across requests. You can provide a custom key by passing a string as the first argument:
+By default, a [unique key is generated](/guide/caching) based in input parameters for each request to ensure that data fetching can be properly de-duplicated across requests. You can provide a custom key by passing a string as the `cache` option:
 
 ```ts
-const key = 'all-posts'
+const route = useRoute()
 
-const data = await $myApi(
-  key,
-  'posts'
-)
+const data = await $myApi('posts', {
+  cache: `posts-${route.params.id}`
+})
 ```
 
 ## Example

--- a/docs/api/my-api.md
+++ b/docs/api/my-api.md
@@ -19,6 +19,7 @@ interface BaseApiFetchOptions {
   /**
    * Cache the response for the same request.
    * If set to `true`, the cache key will be generated from the request options.
+   * Alternatively, a custom cache key can be provided.
    * @default false
    */
   cache?: string | boolean

--- a/docs/api/my-api.md
+++ b/docs/api/my-api.md
@@ -6,6 +6,52 @@
 
 Returns the raw response of the API endpoint. Intended for actions inside methods, e.g. when sending form data to the API when clicking a submit button.
 
+## Type Declarations
+
+```ts
+interface BaseApiFetchOptions {
+  /**
+   * Skip the Nuxt server proxy and fetch directly from the API.
+   * Requires `allowClient` to be enabled in the module options as well.
+   * @default false
+   */
+  client?: boolean
+  /**
+   * Cache the response for the same request
+   * @default false
+   */
+  cache?: boolean
+}
+
+type ApiFetchOptions = Omit<NitroFetchOptions<string>, 'body' | 'cache'> & {
+  pathParams?: Record<string, string>
+  body?: string | Record<string, any> | FormData | null
+}
+
+function $Api<T = any>(
+  path: string,
+  opts?: ApiFetchOptions & BaseApiFetchOptions
+): Promise<T>
+function $Api<T = any>(
+  key: string,
+  path: string,
+  opts?: ApiFetchOptions & BaseApiFetchOptions
+): Promise<T>
+```
+
+## Caching
+
+By default, a [unique key for each request is generated](/guide/caching) to ensure that data fetching can be properly de-duplicated across requests. You can provide a custom key by passing a string as the first argument:
+
+```ts
+const key = 'all-posts'
+
+const data = await $myApi(
+  key,
+  'posts'
+)
+```
+
 ## Example
 
 ::: info
@@ -89,32 +135,4 @@ export default defineNuxtConfig({
     allowClient: true
   }
 })
-```
-
-## Type Declarations
-
-```ts
-interface BaseApiFetchOptions {
-  /**
-   * Skip the Nuxt server proxy and fetch directly from the API.
-   * Requires `allowClient` to be enabled in the module options as well.
-   * @default false
-   */
-  client?: boolean
-  /**
-   * Cache the response for the same request
-   * @default false
-   */
-  cache?: boolean
-}
-
-type ApiFetchOptions = Omit<NitroFetchOptions<string>, 'body' | 'cache'> & {
-  pathParams?: Record<string, string>
-  body?: string | Record<string, any> | FormData | null
-}
-
-type $Api = <T = any>(
-  path: string,
-  opts?: ApiFetchOptions & BaseApiFetchOptions
-) => Promise<T>
 ```

--- a/docs/api/use-my-api-data.md
+++ b/docs/api/use-my-api-data.md
@@ -19,6 +19,73 @@ The composable supports every [`useAsyncData` option](https://nuxt.com/docs/api/
 
 By default, Nuxt waits until a `refresh` is finished before it can be executed again. Passing `true` as parameter skips that wait.
 
+## Type Declarations
+
+```ts
+type BaseUseApiDataOptions<T> = Omit<AsyncDataOptions<T>, 'watch'> & {
+  /**
+   * Skip the Nuxt server proxy and fetch directly from the API.
+   * Requires `allowClient` to be enabled in the module options as well.
+   * @default false
+   */
+  client?: boolean
+  /**
+   * Cache the response for the same request
+   * @default true
+   */
+  cache?: boolean
+  /**
+   * Watch an array of reactive sources and auto-refresh the fetch result when they change.
+   * Fetch options and URL are watched by default. You can completely ignore reactive sources by using `watch: false`.
+   */
+  watch?: (WatchSource<unknown> | object)[] | false
+}
+
+type UseApiDataOptions<T> = Pick<
+  ComputedOptions<NitroFetchOptions<string>>,
+  | 'onRequest'
+  | 'onRequestError'
+  | 'onResponse'
+  | 'onResponseError'
+  | 'query'
+  | 'headers'
+  | 'method'
+  | 'retry'
+  | 'retryDelay'
+  | 'timeout'
+> & {
+  pathParams?: MaybeRef<Record<string, string>>
+  body?: MaybeRef<string | Record<string, any> | FormData | null | undefined>
+} & BaseUseApiDataOptions<T>
+
+function UseApiData<T = any>(
+  path: MaybeRefOrGetter<string>,
+  opts?: UseApiDataOptions<T>
+): AsyncData<T | undefined, FetchError>
+function UseApiData<T = any>(
+  key: MaybeRefOrGetter<string>,
+  path: MaybeRefOrGetter<string>,
+  opts?: UseApiDataOptions<T>
+): AsyncData<T | undefined, FetchError>
+```
+
+## Caching
+
+By default, a [unique key for each request is generated](/guide/caching) to ensure that data fetching can be properly de-duplicated across requests. You can provide a custom key by passing a string as the first argument, just like the native [`useAsyncData`](https://nuxt.com/docs/api/composables/use-async-data):
+
+```ts
+const key = 'all-posts'
+
+const { data } = await useMyApiData(
+  key,
+  'posts'
+)
+```
+
+::: tip
+The key can be a reactive value, e.g. a computed property.
+:::
+
 ## Examples
 
 ::: info
@@ -123,49 +190,4 @@ export default defineNuxtConfig({
     allowClient: true
   }
 })
-```
-
-## Type Declarations
-
-```ts
-type BaseUseApiDataOptions<T> = Omit<AsyncDataOptions<T>, 'watch'> & {
-  /**
-   * Skip the Nuxt server proxy and fetch directly from the API.
-   * Requires `allowClient` to be enabled in the module options as well.
-   * @default false
-   */
-  client?: boolean
-  /**
-   * Cache the response for the same request
-   * @default true
-   */
-  cache?: boolean
-  /**
-   * Watch an array of reactive sources and auto-refresh the fetch result when they change.
-   * Fetch options and URL are watched by default. You can completely ignore reactive sources by using `watch: false`.
-   */
-  watch?: (WatchSource<unknown> | object)[] | false
-}
-
-type UseApiDataOptions<T> = Pick<
-  ComputedOptions<NitroFetchOptions<string>>,
-  | 'onRequest'
-  | 'onRequestError'
-  | 'onResponse'
-  | 'onResponseError'
-  | 'query'
-  | 'headers'
-  | 'method'
-  | 'retry'
-  | 'retryDelay'
-  | 'timeout'
-> & {
-  pathParams?: MaybeRef<Record<string, string>>
-  body?: MaybeRef<string | Record<string, any> | FormData | null | undefined>
-} & BaseUseApiDataOptions<T>
-
-type UseApiData = <T = any>(
-  path: MaybeRefOrGetter<string>,
-  opts?: UseApiDataOptions<T>
-) => AsyncData<T | undefined, FetchError>
 ```

--- a/docs/api/use-my-api-data.md
+++ b/docs/api/use-my-api-data.md
@@ -30,7 +30,7 @@ type BaseUseApiDataOptions<T> = Omit<AsyncDataOptions<T>, 'watch'> & {
    */
   client?: boolean
   /**
-   * Cache the response for the same request
+   * Cache the response for the same request.
    * @default true
    */
   cache?: boolean
@@ -71,15 +71,13 @@ function UseApiData<T = any>(
 
 ## Caching
 
-By default, a [unique key for each request is generated](/guide/caching) to ensure that data fetching can be properly de-duplicated across requests. You can provide a custom key by passing a string as the first argument, just like the native [`useAsyncData`](https://nuxt.com/docs/api/composables/use-async-data):
+By default, a [unique key is generated](/guide/caching) based in input parameters for each request to ensure that data fetching can be properly de-duplicated across requests. You can provide a custom key by passing a string as the first argument, just like the native [`useAsyncData`](https://nuxt.com/docs/api/composables/use-async-data):
 
 ```ts
-const key = 'all-posts'
+const route = useRoute()
+const key = computed(() => `posts-${route.params.id}`)
 
-const { data } = await useMyApiData(
-  key,
-  'posts'
-)
+const { data } = await useMyApiData(key, 'posts')
 ```
 
 ::: tip

--- a/src/runtime/composables/$api.ts
+++ b/src/runtime/composables/$api.ts
@@ -17,6 +17,7 @@ export interface BaseApiFetchOptions {
   /**
    * Cache the response for the same request.
    * If set to `true`, the cache key will be generated from the request options.
+   * Alternatively, a custom cache key can be provided.
    * @default false
    */
   cache?: string | boolean

--- a/src/runtime/composables/$api.ts
+++ b/src/runtime/composables/$api.ts
@@ -52,7 +52,9 @@ export function _$api<T = any>(
   opts: ApiFetchOptions & BaseApiFetchOptions = {},
 ): Promise<T> {
   const nuxt = useNuxtApp()
+  const { apiParty } = useRuntimeConfig().public
   const promiseMap = (nuxt._promiseMap = nuxt._promiseMap || new Map()) as Map<string, Promise<T>>
+
   const {
     pathParams,
     query,
@@ -63,7 +65,7 @@ export function _$api<T = any>(
     cache = false,
     ...fetchOptions
   } = opts
-  const { apiParty } = useRuntimeConfig().public
+
   const key = `$party${hash([
     endpointId,
     path,

--- a/src/runtime/composables/useApiData.ts
+++ b/src/runtime/composables/useApiData.ts
@@ -27,7 +27,7 @@ export type BaseUseApiDataOptions<T> = Omit<AsyncDataOptions<T>, 'watch'> & {
    */
   client?: boolean
   /**
-   * Cache the response for the same request
+   * Cache the response for the same request.
    * @default true
    */
   cache?: boolean


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)
-->

### 🔗 Linked issue

#50

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme or JSDoc annotations)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [x] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Supersedes https://github.com/johannschopplich/nuxt-api-party/pull/51. 

@killjoy1221 Adds support for a custom key to de-duplicate requests, just like `asyncData` does:

```ts
cost route = useRoute()

const { data, pending, error } = await useJsonPlaceholderData<JsonPlaceholderComment>(
  // Key can be reactive
  computed(() => route.params.slug)
  'comments',
  {
    query: computed(() => ({
      postId: `${route.query.postId || 1}`,
    })),
)
```

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
