### PR TITLE
fix: use generics to allow for transform

### DIFF
--- a/playground/pages/petStore.vue
+++ b/playground/pages/petStore.vue
@@ -16,6 +16,12 @@ const { data, error } = usePetStoreData('pet/findByStatus', {
   query: computed(() => ({
     status: status.value ?? 'pending',
   })),
+  transform(response) {
+    return response.map(({ id, name }) => ({
+      id,
+      name,
+    }))
+  },
 })
 
 watch(error, value => console.error(value))


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)
-->

### 🔗 Linked issue

#49 

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme or JSDoc annotations)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->

Introduces two more generics to OpenAPI-typed composables, allowing for use of `transform`, which previously would create a TypeScript error, because return type of the composable — and therefore `transform` method — was forced, rather than inferred from options.

This makes `transform` match its original intent and behaviour from Nuxt, which is to take response data and transform it in some way before exposing as returned `data` ref.

Resolves #49.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [x] I have updated the documentation accordingly.
