### PR TITLE
fix: remove extension from import sources

### DIFF
--- a/src/module.ts
+++ b/src/module.ts
@@ -211,7 +211,7 @@ export const ${getRawComposableName(i)} = (...args) => _$api('${i}', ...args)
 
     // Add Nuxt auto-imports for generated composables
     addImportsSources({
-      from: resolve(nuxt.options.buildDir, `module/${moduleName}.mjs`),
+      from: resolve(nuxt.options.buildDir, `module/${moduleName}`),
       imports: endpointKeys.flatMap(i => [getRawComposableName(i), getDataComposableName(i)]),
     })
 


### PR DESCRIPTION

<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)
-->

### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme or JSDoc annotations)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

This fixes an issue (introduced in 5401fdd6664753a6b3d7b35cd02a17d67b1a806e), which prevents typescript from seeing the module when the .mjs file is not generated, but .d.ts is.

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
