### PR TITLE
fix: options of schemas without parameters resolve to `Record<string, never>`

### DIFF
--- a/src/runtime/openapi.ts
+++ b/src/runtime/openapi.ts
@@ -24,7 +24,7 @@ export type FetchResponseError<T> = NuxtError<
 export type MethodOption<M, P> = 'get' extends keyof P ? { method?: M } : { method: M }
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
-export type ParamsOption<T> = T extends { parameters?: any, query?: any } ? T['parameters'] : Record<string, never>
+export type ParamsOption<T> = T extends { parameters?: any, query?: any } ? T['parameters'] : unknown
 
 export type RequestBodyOption<T> =
   OperationRequestBodyContent<T> extends never


### PR DESCRIPTION

<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)
-->

### 🔗 Linked issue
Fixes #76 
<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme or JSDoc annotations)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description
The type `Record<string, never>` blanks out all keys when combined with other types via `&`. Type composition ignores the `unknown` type.

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
