### PR TITLE
fix: add NitroFetchOptions to UseOpenAPIDataOptions

### DIFF
--- a/src/runtime/composables/useApiData.ts
+++ b/src/runtime/composables/useApiData.ts
@@ -90,6 +90,19 @@ export type UseOpenAPIDataOptions<
   & ComputedOptions<RequestBodyOption<Operation>>
   & Omit<AsyncDataOptions<ResT, DataT>, 'query' | 'body' | 'method'>
   & SharedAsyncDataOptions<ResT, DataT>
+  & Pick<
+    ComputedOptions<NitroFetchOptions<string>>,
+    | 'onRequest'
+    | 'onRequestError'
+    | 'onResponse'
+    | 'onResponseError'
+    | 'query'
+    | 'headers'
+    | 'method'
+    | 'retry'
+    | 'retryDelay'
+    | 'timeout'
+  >
 
 export type UseOpenAPIData<Paths> = <
   ReqT extends Extract<keyof Paths, string>,


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)
-->

### 🔗 Linked issue

[https://github.com/johannschopplich/nuxt-api-party/issues/84](https://github.com/johannschopplich/nuxt-api-party/issues/84)

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme or JSDoc annotations)
- [X] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

This adds the interceptors to the OpenAPIDataOptions.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
