### PR TITLE
fix: rethrow h3 errors caught by the api event handler

### DIFF
--- a/src/module.ts
+++ b/src/module.ts
@@ -221,7 +221,7 @@ ${endpointKeys.map(i => `
 export const ${getRawComposableName(i)} = (...args) => _$api('${i}', ...args)
 `.trimStart()).join('')}`.trimStart()
 
-      if (schemaEndpointIds.length) {
+      if (endpointKeys.length) {
         config.typescript ||= {}
         config.typescript.tsConfig ||= {}
         config.typescript.tsConfig.include ||= []

--- a/src/runtime/server/handler.ts
+++ b/src/runtime/server/handler.ts
@@ -6,6 +6,7 @@ import {
   getRequestHeader,
   getRequestIP,
   getRouterParam,
+  isError,
   readBody,
   send,
   setResponseHeader,
@@ -133,6 +134,9 @@ export default defineEventHandler(async (event) => {
     return send(event, new Uint8Array(response._data ?? []))
   }
   catch (error) {
+    if (isError(error)) {
+      throw error
+    }
     console.error(error)
 
     throw createError({

--- a/test/e2e.test.ts
+++ b/test/e2e.test.ts
@@ -23,6 +23,21 @@ describe('nuxt-api-party', async () => {
     const html = await $fetch<string>('/useTestApiData')
     expect(getTestResult(html)).toMatchSnapshot()
   })
+
+  it('hook doesn\'t swallow h3 errors', async () => {
+    await $fetch('/api/__api_party/forbidden', {
+      method: 'POST',
+      body: {
+        path: '/',
+        method: 'GET',
+      },
+      ignoreResponseError: true,
+
+      onResponse: ({ response }) => {
+        expect(response.status).toBe(401)
+      },
+    })
+  })
 })
 
 function getTestResult(html: string) {

--- a/test/fixture/nuxt.config.ts
+++ b/test/fixture/nuxt.config.ts
@@ -8,6 +8,9 @@ export default defineNuxtConfig({
       testApi: {
         url: '/api',
       },
+      forbidden: {
+        url: '/api',
+      },
     },
   },
 })

--- a/test/fixture/server/plugins/apiAuth.ts
+++ b/test/fixture/server/plugins/apiAuth.ts
@@ -1,0 +1,10 @@
+import { createError, defineNitroPlugin } from '#imports'
+
+export default defineNitroPlugin((nitroApp) => {
+  nitroApp.hooks.hook('api-party:request:forbidden', () => {
+    throw createError({
+      statusCode: 401,
+      statusMessage: 'Unauthorized',
+    })
+  })
+})


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)
-->

### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number as #123 -->
Fixes #105

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme or JSDoc annotations)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->

Instead of rewriting all errors to HTTP 503, it will rethrow it if it's an h3 error.

I also added a test to make sure it's fixed. The test required another bug fix related to type generation, which is included in this PR as a separate commit.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
