### PR TITLE
feat: allow reactive key in useAsyncData on nuxt 3.17

### DIFF
--- a/docs/api/use-fetch-like.md
+++ b/docs/api/use-fetch-like.md
@@ -90,6 +90,8 @@ const { data } = await useMyApiData('posts', {
 
 ::: tip
 The key can be a reactive value, e.g. a computed property.
+
+Requires Nuxt >=3.17 for full reactivity support.
 :::
 
 Clear the cache for a specific query by calling the `clear` function. This will remove the cached data for the query and allow the next request to fetch the data from the server:

--- a/package.json
+++ b/package.json
@@ -57,6 +57,7 @@
     "openapi-typescript-helpers": "0.0.13",
     "pathe": "^2.0.3",
     "scule": "^1.3.0",
+    "semver": "^7.7.2",
     "ufo": "^1.6.1"
   },
   "devDependencies": {
@@ -64,6 +65,7 @@
     "@nuxt/module-builder": "^1.0.1",
     "@nuxt/test-utils": "^3.19.1",
     "@types/node": "^22.15.24",
+    "@types/semver": "^7.7.0",
     "bumpp": "^10.1.1",
     "eslint": "^9.27.0",
     "nuxt": "^3.17.4",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -32,6 +32,9 @@ importers:
       scule:
         specifier: ^1.3.0
         version: 1.3.0
+      semver:
+        specifier: ^7.7.2
+        version: 7.7.2
       ufo:
         specifier: ^1.6.1
         version: 1.6.1
@@ -48,6 +51,9 @@ importers:
       '@types/node':
         specifier: ^22.15.24
         version: 22.15.24
+      '@types/semver':
+        specifier: ^7.7.0
+        version: 7.7.0
       bumpp:
         specifier: ^10.1.1
         version: 10.1.1(magicast@0.3.5)
@@ -1583,6 +1589,9 @@ packages:
 
   '@types/resolve@1.20.2':
     resolution: {integrity: sha512-60BCwRFOZCQhDncwQdxxeOEEkbc5dIMccYLwbxsS4TUNeVECQ/pBJ0j09mrHOl/JJvpRPGwO9SvE4nR2Nb/a4Q==}
+
+  '@types/semver@7.7.0':
+    resolution: {integrity: sha512-k107IF4+Xr7UHjwDc7Cfd6PRQfbdkiRabXGRjo07b4WyPahFBZCZ1sE+BNxYIJPPg73UkfOsVOLwqVc/6ETrIA==}
 
   '@types/triple-beam@1.3.5':
     resolution: {integrity: sha512-6WaYesThRMCl19iryMYP7/x2OVgCtbIVflDGFpWnb9irXI3UjYE4AzmYuiUKY1AJstGijoY+MgUszMgRxIYTYw==}
@@ -7168,6 +7177,8 @@ snapshots:
       parse-path: 7.1.0
 
   '@types/resolve@1.20.2': {}
+
+  '@types/semver@7.7.0': {}
 
   '@types/triple-beam@1.3.5': {}
 

--- a/src/runtime/composables/useApiData.ts
+++ b/src/runtime/composables/useApiData.ts
@@ -4,8 +4,9 @@ import type { MaybeRef, MaybeRefOrGetter, MultiWatchSources } from 'vue'
 import type { ModuleOptions } from '../../module'
 import type { FetchResponseData, FetchResponseError, FilterMethods, ParamsOption, RequestBodyOption } from '../openapi'
 import type { EndpointFetchOptions } from '../types'
-import { useAsyncData, useRequestHeaders, useRuntimeConfig } from '#imports'
+import { useAsyncData, useNuxtApp, useRequestHeaders, useRuntimeConfig } from '#imports'
 import { hash } from 'ohash'
+import { satisfies } from 'semver'
 import { joinURL } from 'ufo'
 import { computed, reactive, toValue } from 'vue'
 import { CACHE_KEY_PREFIX } from '../constants'
@@ -109,6 +110,11 @@ export type UseOpenAPIData<Paths> = <
   autoKey?: string
 ) => AsyncData<DataT | null, ErrorT>
 
+function checkNuxtVersion(constraint: string) {
+  const nuxtApp = useNuxtApp()
+  return satisfies(nuxtApp.versions.nuxt, constraint)
+}
+
 export function _useApiData<T = unknown>(
   endpointId: string,
   path: MaybeRefOrGetter<string>,
@@ -182,7 +188,7 @@ export function _useApiData<T = unknown>(
   let controller: AbortController | undefined
 
   return useAsyncData<T, unknown>(
-    _key.value,
+    checkNuxtVersion('>=3.17') ? _key : _key.value,
     async (nuxt) => {
       controller?.abort?.()
 


### PR DESCRIPTION

<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)
-->

### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number as #123 -->
Resolves #104

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme or JSDoc annotations)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [x] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->

Nuxt 3.17 added support for reactive keys in `useAsyncData`. This change adds logic to pass the key ref directly if nuxt >= 3.17.

An alternative implementation involved passing the ref to `useAsyncData` unconditionally and changing the required Nuxt version to 3.17.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [x] I have updated the documentation accordingly.
