### PR TITLE
fix: explicitly handle only known hooks in mergeFetchHooks function

### DIFF
--- a/src/runtime/hooks.ts
+++ b/src/runtime/hooks.ts
@@ -11,9 +11,10 @@ export function mergeFetchHooks(...hooks: FetchHooks[]): FetchHooks {
   }
 
   for (const hook of hooks) {
-    for (const [key, value] of Object.entries(hook)) {
-      maybePush(result[key as keyof typeof result], value)
-    }
+    maybePush(result.onRequest, hook.onRequest)
+    maybePush(result.onResponse, hook.onResponse)
+    maybePush(result.onRequestError, hook.onRequestError)
+    maybePush(result.onResponseError, hook.onResponseError)
   }
 
   return result


### PR DESCRIPTION

<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)
-->

### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme or JSDoc annotations)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->

This fixes an issue where additional fetch options would be treated as hooks and merged, which throws an error "Cannot read properties of undefined (reading 'push')"

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
