### PR TITLE
docs: deduplicate type declarations copied from source files

### DIFF
--- a/docs/api/dollarfetch-like.md
+++ b/docs/api/dollarfetch-like.md
@@ -8,42 +8,7 @@ Returns the raw response of the API endpoint. Intended for actions inside method
 
 ## Type Declarations
 
-```ts
-interface SharedFetchOptions {
-  /**
-   * Skip the Nuxt server proxy and fetch directly from the API.
-   * Requires `client` set to `true` in the module options.
-   * @remarks
-   * If Nuxt SSR is disabled, client-side requests are enabled by default.
-   * @default false
-   */
-  client?: boolean
-  /**
-   * Cache the response for the same request.
-   * You can customize the cache key with the `key` option.
-   * @default false
-   */
-  cache?: boolean
-  /**
-   * By default, a cache key will be generated from the request options.
-   * With this option, you can provide a custom cache key.
-   * @default undefined
-   */
-  key?: string
-}
-
-type ApiClientFetchOptions
-  = Omit<NitroFetchOptions<string>, 'body' | 'cache'>
-    & {
-      path?: Record<string, string>
-      body?: string | Record<string, any> | FormData | null
-    }
-
-function $Api<T = unknown>(
-  path: string,
-  opts?: ApiClientFetchOptions & SharedFetchOptions
-): Promise<T>
-```
+<<< @/../src/runtime/composables/$api.ts#options
 
 ## Caching
 

--- a/docs/api/use-fetch-like.md
+++ b/docs/api/use-fetch-like.md
@@ -22,59 +22,7 @@ By default, Nuxt waits until a `refresh` is finished before it can be executed a
 
 ## Type Declarations
 
-```ts
-type SharedAsyncDataOptions<ResT, DataT = ResT> = Omit<AsyncDataOptions<ResT, DataT>, 'watch'> & {
-  /**
-   * Skip the Nuxt server proxy and fetch directly from the API.
-   * Requires `client` set to `true` in the module options.
-   * @remarks
-   * If Nuxt SSR is disabled, client-side requests are enabled by default.
-   * @default false
-   */
-  client?: boolean
-  /**
-   * Cache the response for the same request.
-   * You can customize the cache key with the `key` option.
-   * @default true
-   */
-  cache?: boolean
-  /**
-   * By default, a cache key will be generated from the request options.
-   * With this option, you can provide a custom cache key.
-   * @default undefined
-   */
-  key?: MaybeRefOrGetter<string>
-  /**
-   * Watch an array of reactive sources and auto-refresh the fetch result when they change.
-   * Fetch options and URL are watched by default. You can completely ignore reactive sources by using `watch: false`.
-   * @default undefined
-   */
-  watch?: MultiWatchSources | false
-}
-
-type UseApiDataOptions<T> = Pick<
-  ComputedOptions<NitroFetchOptions<string>>,
-  | 'onRequest'
-  | 'onRequestError'
-  | 'onResponse'
-  | 'onResponseError'
-  | 'query'
-  | 'headers'
-  | 'method'
-  | 'retry'
-  | 'retryDelay'
-  | 'retryStatusCodes'
-  | 'timeout'
-> & {
-  path?: MaybeRefOrGetter<Record<string, string>>
-  body?: MaybeRef<string | Record<string, any> | FormData | null>
-} & SharedAsyncDataOptions<T>
-
-function UseApiData<T = unknown>(
-  path: MaybeRefOrGetter<string>,
-  opts?: UseApiDataOptions<T>
-): AsyncData<T | null, NuxtError>
-```
+<<< @/../src/runtime/composables/useApiData.ts#options
 
 ## Caching
 

--- a/docs/config/index.md
+++ b/docs/config/index.md
@@ -36,20 +36,7 @@ Default value: `{}`
 
 **Type**
 
-```ts
-interface EndpointConfiguration {
-  url: string
-  token?: string
-  query?: QueryObject
-  headers?: HeadersInit
-  cookies?: boolean
-  allowedUrls?: string[]
-  schema?: string | OpenAPI3
-  openAPITS?: OpenAPITSOptions
-}
-
-type ApiPartyEndpoints = Record<string, EndpointConfiguration> | undefined
-```
+<<< @/../src/module.ts#endpoints
 
 **Example**
 
@@ -85,77 +72,5 @@ The global [configuration options](https://openapi-ts.pages.dev/node/#options) f
 
 ## Type Declaration
 
-```ts
-interface EndpointConfiguration {
-  url: string
-  token?: string
-  query?: QueryObject
-  headers?: HeadersInit
-  cookies?: boolean
-  allowedUrls?: string[]
-  schema?: string | URL | OpenAPI3 | (() => Promise<OpenAPI3>)
-  openAPITS?: OpenAPITSOptions
-}
+<<< @/../src/module.ts#options
 
-interface ModuleOptions {
-  /**
-   * API endpoints
-   *
-   * @remarks
-   * Each key represents an endpoint ID, which is used to generate the composables. The value is an object with the following properties:
-   * - `url`: The URL of the API endpoint
-   * - `token`: The API token to use for the endpoint (optional)
-   * - `query`: Query parameters to send with each request (optional)
-   * - `headers`: Headers to send with each request (optional)
-   * - `cookies`: Whether to send cookies with each request (optional)
-   * - `allowedUrls`: A list of allowed URLs to change the [backend URL at runtime](https://nuxt-api-party.byjohann.dev/guide/dynamic-backend-url) (optional)
-   * - `schema`: A URL, file path, object, or async function pointing to an [OpenAPI Schema](https://swagger.io/resources/open-api) used to [generate types](/guide/openapi-types) (optional)
-   * - `openAPITS`: [Configuration options](https://openapi-ts.pages.dev/node/#options) for `openapi-typescript`. Options defined here will override the global `openAPITS`
-   *
-   * @example
-   * export default defineNuxtConfig({
-   *   apiParty: {
-   *     endpoints: {
-   *       jsonPlaceholder: {
-   *         url: 'https://jsonplaceholder.typicode.com'
-   *         headers: {
-   *           Authorization: `Basic ${globalThis.btoa('username:password')}`
-   *         }
-   *       }
-   *     }
-   *   }
-   * })
-   *
-   * @default {}
-   */
-  endpoints?: Record<string, EndpointConfiguration>
-
-  /**
-   * Allow client-side requests besides server-side ones
-   *
-   * @remarks
-   * By default, API requests are only made on the server-side. This option allows you to make requests on the client-side as well. Keep in mind that this will expose your API credentials to the client.
-   * Note: If Nuxt SSR is disabled, all requests are made on the client-side by default.
-   *
-   * @example
-   * useJsonPlaceholderData('/posts/1', { client: true })
-   *
-   * @default false
-   */
-  client?: boolean | 'allow' | 'always'
-
-  /**
-   * Global options for openapi-typescript
-   */
-  openAPITS?: OpenAPITSOptions
-
-  server?: {
-    /**
-     * The API base path for the Nuxt server handler
-     *
-     * @default '__api_party'
-     */
-    basePath?: string
-  }
-}
-```

--- a/src/module.ts
+++ b/src/module.ts
@@ -12,6 +12,8 @@ import { joinURL } from 'ufo'
 import { name } from '../package.json'
 import { generateDeclarationTypes } from './openapi'
 
+// #region options
+// #region endpoints
 export interface EndpointConfiguration {
   url: string
   token?: string
@@ -22,6 +24,7 @@ export interface EndpointConfiguration {
   schema?: string | OpenAPI3
   openAPITS?: OpenAPITSOptions
 }
+// #endregion endpoints
 
 export interface ModuleOptions {
   /**
@@ -84,6 +87,7 @@ export interface ModuleOptions {
     basePath?: string
   }
 }
+// #endregion options
 
 declare module '@nuxt/schema' {
   interface RuntimeConfig {

--- a/src/runtime/composables/$api.ts
+++ b/src/runtime/composables/$api.ts
@@ -11,6 +11,7 @@ import { mergeFetchHooks } from '../hooks'
 import { resolvePathParams } from '../openapi'
 import { mergeHeaders, serializeMaybeEncodedBody } from '../utils'
 
+// #region options
 export interface SharedFetchOptions {
   /**
    * Skip the Nuxt server proxy and fetch directly from the API.
@@ -41,6 +42,12 @@ export type ApiClientFetchOptions
       body?: string | Record<string, any> | FormData | null
     }
 
+export type ApiClient = <T = unknown>(
+  path: string,
+  opts?: ApiClientFetchOptions & SharedFetchOptions,
+) => Promise<T>
+// #endregion options
+
 export type OpenAPIClientFetchOptions<
   Method,
   LowercasedMethod,
@@ -52,10 +59,6 @@ export type OpenAPIClientFetchOptions<
   & Omit<NitroFetchOptions<string>, 'query' | 'body' | 'method' | 'cache'>
   & SharedFetchOptions
 
-export type ApiClient = <T = unknown>(
-  path: string,
-  opts?: ApiClientFetchOptions & SharedFetchOptions,
-) => Promise<T>
 
 export type OpenAPIClient<Paths> = <
   ReqT extends Extract<keyof Paths, string>,

--- a/src/runtime/composables/useApiData.ts
+++ b/src/runtime/composables/useApiData.ts
@@ -25,6 +25,7 @@ type ComputedOptions<T> = {
 
 type ComputedMethodOption<M, P> = 'get' extends keyof P ? ComputedOptions<{ method?: M }> : ComputedOptions<{ method: M }>
 
+// #region options
 export type SharedAsyncDataOptions<ResT, DataT = ResT> = Omit<AsyncDataOptions<ResT, DataT>, 'watch'> & {
   /**
    * Skip the Nuxt server proxy and fetch directly from the API.
@@ -78,6 +79,7 @@ export type UseApiData = <T = unknown>(
   path: MaybeRefOrGetter<string>,
   opts?: UseApiDataOptions<T>,
 ) => AsyncData<T | null, NuxtError>
+// #endregion options
 
 export type UseOpenAPIDataOptions<
   Method,


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)
-->

### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [x] 📖 Documentation (updates to the documentation, readme or JSDoc annotations)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

This change takes advantage of vitepress's markdownit extension [code snippets](https://vitepress.dev/guide/markdown#import-code-snippets). Specifically its support for including lines between `#region`/`#endregion` comments.

Any updates to typing between the region comments should automatically be included in the docs.

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [x] I have updated the documentation accordingly.
