### PR TITLE
refactor: don't hash keys passed in by the user

### DIFF
--- a/src/runtime/composables/$api.ts
+++ b/src/runtime/composables/$api.ts
@@ -92,16 +92,14 @@ export function _$api<T = unknown>(
     ...fetchOptions
   } = opts
 
-  const _key = key === undefined
-    ? CACHE_KEY_PREFIX + hash([
-      endpointId,
-      path,
-      pathParams,
-      query,
-      method,
-      ...(isFormData(body) ? [] : [body]),
-    ])
-    : CACHE_KEY_PREFIX + key
+  const _key = key || CACHE_KEY_PREFIX + hash([
+    endpointId,
+    path,
+    pathParams,
+    query,
+    method,
+    ...(isFormData(body) ? [] : [body]),
+  ])
 
   if (client && !allowClient)
     throw new Error('Client-side API requests are disabled. Set "client: true" in the module options to enable them.')

--- a/src/runtime/composables/useApiData.ts
+++ b/src/runtime/composables/useApiData.ts
@@ -124,16 +124,14 @@ export function _useApiData<T = unknown>(
   } = opts
 
   const _path = computed(() => resolvePathParams(toValue(path), toValue(pathParams)))
-  const _key = computed(key === undefined
-    ? () => CACHE_KEY_PREFIX + hash([
-        autoKey,
-        endpointId,
-        _path.value,
-        toValue(opts.query),
-        toValue(opts.method),
-        ...(isFormData(toValue(opts.body)) ? [] : [toValue(opts.body)]),
-      ])
-    : () => CACHE_KEY_PREFIX + toValue(key),
+  const _key = computed(() => toValue(key) || (CACHE_KEY_PREFIX + hash([
+    autoKey,
+    endpointId,
+    _path.value,
+    toValue(opts.query),
+    toValue(opts.method),
+    ...(isFormData(toValue(opts.body)) ? [] : [toValue(opts.body)]),
+  ])),
   )
 
   if (client && !allowClient)


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)
-->

### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme or JSDoc annotations)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Makes custom keys behave in a less unexpected way, more similar to `useFetch`. The key will be used as is and can be reused in `useNuxtData`.

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
