### PR TITLE
docs: add example plugin for handing redirects

### DIFF
--- a/examples/rewrite-redirects/.nuxtrc
+++ b/examples/rewrite-redirects/.nuxtrc
@@ -1,0 +1,1 @@
+imports.autoImport=true

--- a/examples/rewrite-redirects/README.md
+++ b/examples/rewrite-redirects/README.md
@@ -1,0 +1,21 @@
+# Rewrite Redirects
+
+This example showcases a Nitropack plugin that rewrites redirect locations.
+
+The default behavior is to follow redirects automatically, which can obscure the original redirect location from the client. This plugin allows redirects to be forwarded to the client transparently.
+
+> [!WARNING]
+> In order to use this plugin, you need to enable the experimental api party option `enablePrefixedProxy`. Due to how clients implement redirects, supporting non-prefixed proxy requests is not possible.
+
+## Usage
+
+To take advantage of this plugin, execute a request with the `x-proxy-redirect` header set to `manual`. This instructs the proxy to not follow redirects automatically.
+
+When a redirect response is received (HTTP status codes 3xx), the plugin captures the original `Location` header and rewrites it to be relative to the endpoint base URL. The rewritten location is then included in the response headers as `x-proxy-location`.
+
+> [!NOTE]
+> If your endpoint responds with a redirect which points a location outside of the endpoint base URL, a 502 Bad Gateway error will be returned to the client. This is a security measure to prevent open redirect vulnerabilities.
+
+### Request Headers
+
+- `x-proxy-redirect`: Sets the redirect mode for the proxy request. Valid values are `'follow' | 'error' | 'manual'`.

--- a/examples/rewrite-redirects/app/app.vue
+++ b/examples/rewrite-redirects/app/app.vue
@@ -1,0 +1,13 @@
+<script setup lang="ts">
+const { data } = await useMyApiData<{ message: string }>('/api/willredirect', {
+  headers: {
+    'x-proxy-redirect': 'manual',
+  },
+})
+</script>
+
+<template>
+  <div>
+    Message: {{ data?.message }}
+  </div>
+</template>

--- a/examples/rewrite-redirects/nuxt.config.ts
+++ b/examples/rewrite-redirects/nuxt.config.ts
@@ -1,0 +1,15 @@
+export default defineNuxtConfig({
+  modules: [
+    'nuxt-api-party',
+  ],
+  apiParty: {
+    experimental: {
+      enablePrefixedProxy: true,
+    },
+    endpoints: {
+      myApi: {
+        url: '/api',
+      },
+    },
+  },
+})

--- a/examples/rewrite-redirects/server/api/[...].ts
+++ b/examples/rewrite-redirects/server/api/[...].ts
@@ -1,0 +1,5 @@
+export default defineEventHandler((event) => {
+  event.node.res.setHeader('Location', '/api/hello')
+  event.node.res.statusCode = 302
+  event.node.res.end()
+})

--- a/examples/rewrite-redirects/server/api/hello.get.ts
+++ b/examples/rewrite-redirects/server/api/hello.get.ts
@@ -1,0 +1,3 @@
+export default defineEventHandler(() => {
+  return { message: 'Hello, World!' }
+})

--- a/examples/rewrite-redirects/server/plugins/rewrite-redirects.ts
+++ b/examples/rewrite-redirects/server/plugins/rewrite-redirects.ts
@@ -1,0 +1,97 @@
+import type { H3Event } from 'h3'
+import { hasLeadingSlash, hasProtocol, joinURL, withoutBase } from 'ufo'
+
+const REDIRECT_STATUSES = new Set([301, 302, 303, 307, 308])
+const REDIRECT_MODES = new Set(['follow', 'error', 'manual'])
+
+/**
+ * Nitro plugin to rewrite API request and response redirect behavior.
+ *
+ * Note:
+ * This plugin requires that the `experimental.enablePrefixedProxy` option is enabled.
+ * Having this option disabled would cause some redirects to change from POST to GET, which
+ * would result in a 405 error on the proxy.
+ *
+ * Request headers:
+ * - `x-proxy-redirect`: Sets the redirect mode for the proxy request. Valid values are 'follow', 'error', and 'manual'.
+ *
+ * Response headers:
+ * - `x-proxy-location`: Contains the original 'Location' header relative to the endpoint base url
+ */
+export default defineNitroPlugin(async (nitroApp) => {
+  nitroApp.hooks.hook('api-party:request', ({ options }, event) => {
+    // Set redirect mode from request header
+    const redirect = getRequestHeader(event, 'x-proxy-redirect')
+    if (redirect && REDIRECT_MODES.has(redirect)) {
+      options.redirect = redirect as RequestRedirect
+    }
+  })
+
+  nitroApp.hooks.hook('api-party:response', ({ options, response }, event) => {
+    // Handle manual redirect responses
+    if (options.redirect === 'manual' && REDIRECT_STATUSES.has(response.status)) {
+      handleRedirectResponse(event, response)
+    }
+  })
+})
+
+function getEndpointUrl(event: H3Event, endpointId: string) {
+  const { apiParty } = useRuntimeConfig(event)
+  const endpoint = apiParty.endpoints[endpointId as keyof typeof apiParty.endpoints]!
+
+  // should be safe, this header isn't used to kick off any new requests.
+  // and it's called after api-party has already validated the header
+  return getRequestHeader(event, `${endpointId}-endpoint-url`) || endpoint.url
+}
+
+function handleRedirectResponse(event: H3Event, response: Response) {
+  let location = response.headers.get('location')
+  if (!location) {
+    // No location header? Probably nothing to worry about.
+    return
+  }
+
+  // No need to rewrite relative URLs without a leading slash or protocol.
+  // example: some/path or ?query=string
+  // Should be handled automatically by the client.
+  if (!hasProtocol(location) && !hasLeadingSlash(location)) {
+    return
+  }
+
+  const reqUrl = getRequestURL(event)
+  const { endpointId, path } = getRouterParams(event) as { endpointId: string, path: string }
+
+  // Construct absolute URL based on the request for URLs without a
+  // protocol/host and with a leading slash.
+
+  // for when the endpoint url points to a local nitro path.
+  // e.g. { url: '/api' }
+  const baseUrl = new URL(getEndpointUrl(event, endpointId), reqUrl)
+  // for when the redirect points to the same server
+  // e.g. Location: /other-path
+  const locUrl = new URL(location, baseUrl)
+
+  // Clean up absolute same-origin redirects. If the location is outside
+  // of the base URL, we should error out to avoid invalid redirects.
+  location = withoutBase(locUrl.href, baseUrl.href)
+  if (location === locUrl.href) {
+    throw createError({
+      statusCode: 502,
+      statusMessage: 'Bad Gateway',
+      message: 'Server sent Location header pointing outside base URL or to external resource.',
+    })
+  }
+
+  // write the original location header
+  setResponseHeader(event, 'x-proxy-location', location)
+
+  // rewrite relative location to be absolute based on the API Party endpoint.
+  // uses the request path to account for custom api path prefixes. (default: /api/__api_party)
+  location = joinURL(reqUrl.pathname.slice(0, -path.length), location)
+
+  // Write the required status and headers, then end the response to prevent
+  // sendProxy from overwriting the Location header.
+  setResponseStatus(event, response.status, response.statusText)
+  setResponseHeader(event, 'location', location)
+  event.node.res.end()
+}

--- a/examples/rewrite-redirects/tsconfig.json
+++ b/examples/rewrite-redirects/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "references": [
+    { "path": "./.nuxt/tsconfig.app.json" },
+    { "path": "./.nuxt/tsconfig.server.json" },
+    { "path": "./.nuxt/tsconfig.shared.json" },
+    { "path": "./.nuxt/tsconfig.node.json" }
+  ],
+  "files": []
+}

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "prepack": "nuxt-module-build build",
     "dev": "nuxt dev playground",
     "dev:build": "nuxt build playground",
-    "dev:prepare": "nuxt-module-build build --stub && nuxt-module-build prepare && nuxt prepare playground && nuxt prepare test/fixture",
+    "dev:prepare": "zx ./scripts/prepare-all.ts",
     "docs:dev": "vitepress dev docs",
     "docs:build": "vitepress build docs",
     "docs:preview": "vitepress preview docs",
@@ -77,6 +77,7 @@
     "openapi-typescript": "^7.10.1",
     "typescript": "^5.9.3",
     "vitest": "^3.2.4",
-    "vue-tsc": "^3.1.5"
+    "vue-tsc": "^3.1.5",
+    "zx": "^8.8.5"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -75,6 +75,9 @@ importers:
       vue-tsc:
         specifier: ^3.1.5
         version: 3.1.5(typescript@5.9.3)
+      zx:
+        specifier: ^8.8.5
+        version: 8.8.5
 
   docs:
     devDependencies:
@@ -5658,6 +5661,11 @@ packages:
 
   zwitch@2.0.4:
     resolution: {integrity: sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==}
+
+  zx@8.8.5:
+    resolution: {integrity: sha512-SNgDF5L0gfN7FwVOdEFguY3orU5AkfFZm9B5YSHog/UDHv+lvmd82ZAsOenOkQixigwH2+yyH198AwNdKhj+RA==}
+    engines: {node: '>= 12.17.0'}
+    hasBin: true
 
 snapshots:
 
@@ -12016,3 +12024,5 @@ snapshots:
       readable-stream: 4.7.0
 
   zwitch@2.0.4: {}
+
+  zx@8.8.5: {}

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,6 +1,7 @@
 packages:
   - docs
   - playground
+  - examples/*
 
 onlyBuiltDependencies:
   - '@parcel/watcher'

--- a/scripts/prepare-all.ts
+++ b/scripts/prepare-all.ts
@@ -1,4 +1,5 @@
 #!/usr/bin/env zx
+
 /*
 * Prepare all Nuxt projects in the repository using glob patterns.
 */

--- a/scripts/prepare-all.ts
+++ b/scripts/prepare-all.ts
@@ -1,0 +1,24 @@
+#!/usr/bin/env zx
+/*
+* Prepare all Nuxt projects in the repository using glob patterns.
+*/
+/// <reference types="zx/globals" />
+
+import { dirname } from 'node:path'
+
+$ = $({
+  verbose: true,
+  stdio: 'inherit',
+})
+
+const configFiles = await globby('**/nuxt.config.ts', {
+  deep: 3,
+  ignore: ['**/node_modules/**'],
+})
+
+await $`nuxt-build-module build --stub`
+await $`nuxt-build-module prepare`
+
+for (const file of configFiles) {
+  await $`nuxt prepare ${dirname(file)}`
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,4 +1,4 @@
 {
   "extends": "./.nuxt/tsconfig.json",
-  "exclude": ["dist", "playground", "test"]
+  "exclude": ["dist", "playground", "test", "examples"]
 }


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)
-->

### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number as #123 -->
#142 

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [x] 📖 Documentation (updates to the documentation, readme or JSDoc annotations)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->

- Adds an example showcasing a plugin for rewriting redirects.
- To simplify running of `nuxt prepare`, I also added `zx` as a dev dependency and wrote `scripts/prepare-all.ts` to prepare every directory containing a nuxt.config.ts file. Not sure how I feel about that change compared to adding examples as a pnpm package and using `pnpm --filter './examples/*' exec nuxt prepare` or just hard-scripting the prepare of each example.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [x] I have updated the documentation accordingly.
